### PR TITLE
Add check: Incorrect delimiter

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,14 +27,25 @@ Detects if a line starts with a space or a tab character:
 DEBUG_HTTP=true
 ```
 
+### Incorrect delimiter
+
+Detects if a key does not use an underscore to sepearte words:
+```env
+# Wrong
+DB-NAME=testing
+
+# Correct
+DB_NAME=test
+```
+
 ## Roadmap
 - [ ] Add more checks:
   - [x] Leading Space
+  - [x] Incorrect delimiter
   - [ ] [Unordered keys](https://github.com/mgrachev/dotenv-linter/issues/4);
   - [ ] [Duplicated keys](https://github.com/mgrachev/dotenv-linter/issues/5);
   - [ ] [Lowercase keys](https://github.com/mgrachev/dotenv-linter/issues/6);
   - [ ] [Keys without values](https://github.com/mgrachev/dotenv-linter/issues/7);
-  - [x] Incorrect delimiter
   - [ ] [Spaces before or after the character `=`](https://github.com/mgrachev/dotenv-linter/issues/9);
   - [ ] Other checks.
 - [ ] Support [reviewdog](https://github.com/reviewdog/reviewdog);

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ DEBUG_HTTP=true
   - [ ] [Duplicated keys](https://github.com/mgrachev/dotenv-linter/issues/5);
   - [ ] [Lowercase keys](https://github.com/mgrachev/dotenv-linter/issues/6);
   - [ ] [Keys without values](https://github.com/mgrachev/dotenv-linter/issues/7);
-  - [ ] [Incorrect delimiter](https://github.com/mgrachev/dotenv-linter/issues/8);
+  - [x] Incorrect delimiter
   - [ ] [Spaces before or after the character `=`](https://github.com/mgrachev/dotenv-linter/issues/9);
   - [ ] Other checks.
 - [ ] Support [reviewdog](https://github.com/reviewdog/reviewdog);

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ RAILS_ENV=development
 
 ### Incorrect delimiter
 
-Detects if a key does not use an underscore to sepearte words:
+Detects if a key does not use an underscore to separate words:
 ```env
 # Wrong
 DB-NAME=testing

--- a/src/checks.rs
+++ b/src/checks.rs
@@ -30,7 +30,7 @@ trait Check {
 fn checklist() -> Vec<Box<dyn Check>> {
     vec![
         Box::new(leading_space::LeadingSpaceChecker::default()),
-        Box::new(incorrect_delimiter::IncorrectDelimiterChecker {}),
+        Box::new(incorrect_delimiter::IncorrectDelimiterChecker::default()),
     ]
 }
 

--- a/src/checks.rs
+++ b/src/checks.rs
@@ -1,6 +1,7 @@
 use crate::LineEntry;
 use std::fmt;
 
+mod incorrect_delimiter;
 mod leading_space;
 
 #[derive(Debug, Clone, PartialEq)]
@@ -26,8 +27,11 @@ trait Check {
     fn run(&self, line: &LineEntry) -> Option<Warning>;
 }
 
-fn checklist() -> Vec<impl Check> {
-    vec![leading_space::LeadingSpaceChecker::default()]
+fn checklist() -> Vec<Box<dyn Check>> {
+    vec![
+        Box::new(leading_space::LeadingSpaceChecker::default()),
+        Box::new(incorrect_delimiter::IncorrectDelimiterChecker {}),
+    ]
 }
 
 pub fn run(line: &LineEntry) -> Vec<Warning> {

--- a/src/checks/incorrect_delimiter.rs
+++ b/src/checks/incorrect_delimiter.rs
@@ -1,12 +1,22 @@
 use crate::checks::{Check, Warning};
 use crate::LineEntry;
 
-pub(crate) struct IncorrectDelimiterChecker {
-    warning: Warning,
-}
+pub(crate) struct IncorrectDelimiterChecker {}
 
 impl Check for IncorrectDelimiterChecker {
     fn run(&self, line: &LineEntry) -> Option<Warning> {
+        if line.raw_string.starts_with(' ') {
+            return None;
+        }
+
+        let eq_index = line.raw_string.find('=')?;
+        let key = line.raw_string.get(0..eq_index)?;
+        if key.chars().any(|c| !c.is_alphabetic() && c != '_') {
+            return Some(Warning {
+                message: format!("The {} key has incorrect delimiter", key),
+            });
+        }
+
         None
     }
 }
@@ -16,5 +26,64 @@ mod tests {
     use super::*;
 
     #[test]
-    fn incorrect_delimiter_checker_run() {}
+    fn working_run() {
+        let checker = IncorrectDelimiterChecker {};
+        let line = &LineEntry {
+            number: 1,
+            raw_string: String::from("DEBUG_HTTP=true"),
+        };
+        assert_eq!(None, checker.run(line));
+    }
+
+    #[test]
+    fn failing_run() {
+        let checker = IncorrectDelimiterChecker {};
+        let line = &LineEntry {
+            number: 1,
+            raw_string: String::from("DEBUG-HTTP=true"),
+        };
+        let expected =
+            Some(Warning::new("The DEBUG-HTTP key has incorrect delimiter"));
+        assert_eq!(expected, checker.run(line));
+    }
+
+    #[test]
+    fn unformated_run() {
+        let checker = IncorrectDelimiterChecker {};
+        let line = &LineEntry {
+            number: 1,
+            raw_string: String::from("DEBUG-HTTPtrue"),
+        };
+        assert_eq!(None, checker.run(line));
+    }
+
+    #[test]
+    fn leading_space_run() {
+        let checker = IncorrectDelimiterChecker {};
+        let line = &LineEntry {
+            number: 1,
+            raw_string: String::from(" DEBUG_HTTP=true"),
+        };
+        assert_eq!(None, checker.run(line));
+    }
+
+    #[test]
+    fn empty_run() {
+        let checker = IncorrectDelimiterChecker {};
+        let line = &LineEntry {
+            number: 1,
+            raw_string: String::from(""),
+        };
+        assert_eq!(None, checker.run(line));
+    }
+
+    #[test]
+    fn short_run() {
+        let checker = IncorrectDelimiterChecker {};
+        let line = &LineEntry {
+            number: 1,
+            raw_string: String::from("A=short"),
+        };
+        assert_eq!(None, checker.run(line));
+    }
 }

--- a/src/checks/incorrect_delimiter.rs
+++ b/src/checks/incorrect_delimiter.rs
@@ -1,0 +1,20 @@
+use crate::checks::{Check, Warning};
+use crate::LineEntry;
+
+pub(crate) struct IncorrectDelimiterChecker {
+    warning: Warning,
+}
+
+impl Check for IncorrectDelimiterChecker {
+    fn run(&self, line: &LineEntry) -> Option<Warning> {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn incorrect_delimiter_checker_run() {}
+}

--- a/src/checks/incorrect_delimiter.rs
+++ b/src/checks/incorrect_delimiter.rs
@@ -42,8 +42,7 @@ mod tests {
             number: 1,
             raw_string: String::from("DEBUG-HTTP=true"),
         };
-        let expected =
-            Some(Warning::new("The DEBUG-HTTP key has incorrect delimiter"));
+        let expected = Some(Warning::new("The DEBUG-HTTP key has incorrect delimiter"));
         assert_eq!(expected, checker.run(line));
     }
 

--- a/src/checks/incorrect_delimiter.rs
+++ b/src/checks/incorrect_delimiter.rs
@@ -1,7 +1,17 @@
 use crate::checks::{Check, Warning};
 use crate::LineEntry;
 
-pub(crate) struct IncorrectDelimiterChecker {}
+pub(crate) struct IncorrectDelimiterChecker {
+    warning: Warning,
+}
+
+impl Default for IncorrectDelimiterChecker {
+    fn default() -> Self {
+        Self {
+            warning: Warning::new("The {} key has incorrect delimiter"),
+        }
+    }
+}
 
 impl Check for IncorrectDelimiterChecker {
     fn run(&self, line: &LineEntry) -> Option<Warning> {
@@ -13,7 +23,7 @@ impl Check for IncorrectDelimiterChecker {
         let key = line.raw_string.get(0..eq_index)?;
         if key.chars().any(|c| !c.is_alphabetic() && c != '_') {
             return Some(Warning {
-                message: format!("The {} key has incorrect delimiter", key),
+                message: self.warning.message.replace("{}", key),
             });
         }
 
@@ -27,7 +37,7 @@ mod tests {
 
     #[test]
     fn working_run() {
-        let checker = IncorrectDelimiterChecker {};
+        let checker = IncorrectDelimiterChecker::default();
         let line = &LineEntry {
             number: 1,
             raw_string: String::from("DEBUG_HTTP=true"),
@@ -37,7 +47,7 @@ mod tests {
 
     #[test]
     fn failing_run() {
-        let checker = IncorrectDelimiterChecker {};
+        let checker = IncorrectDelimiterChecker::default();
         let line = &LineEntry {
             number: 1,
             raw_string: String::from("DEBUG-HTTP=true"),
@@ -48,7 +58,7 @@ mod tests {
 
     #[test]
     fn unformated_run() {
-        let checker = IncorrectDelimiterChecker {};
+        let checker = IncorrectDelimiterChecker::default();
         let line = &LineEntry {
             number: 1,
             raw_string: String::from("DEBUG-HTTPtrue"),
@@ -58,7 +68,7 @@ mod tests {
 
     #[test]
     fn leading_space_run() {
-        let checker = IncorrectDelimiterChecker {};
+        let checker = IncorrectDelimiterChecker::default();
         let line = &LineEntry {
             number: 1,
             raw_string: String::from(" DEBUG_HTTP=true"),
@@ -68,7 +78,7 @@ mod tests {
 
     #[test]
     fn empty_run() {
-        let checker = IncorrectDelimiterChecker {};
+        let checker = IncorrectDelimiterChecker::default();
         let line = &LineEntry {
             number: 1,
             raw_string: String::from(""),
@@ -78,7 +88,7 @@ mod tests {
 
     #[test]
     fn short_run() {
-        let checker = IncorrectDelimiterChecker {};
+        let checker = IncorrectDelimiterChecker::default();
         let line = &LineEntry {
             number: 1,
             raw_string: String::from("A=short"),

--- a/src/checks/incorrect_delimiter.rs
+++ b/src/checks/incorrect_delimiter.rs
@@ -15,13 +15,9 @@ impl Default for IncorrectDelimiterChecker {
 
 impl Check for IncorrectDelimiterChecker {
     fn run(&self, line: &LineEntry) -> Option<Warning> {
-        if line.raw_string.starts_with(' ') {
-            return None;
-        }
-
         let eq_index = line.raw_string.find('=')?;
         let key = line.raw_string.get(0..eq_index)?;
-        if key.chars().any(|c| !c.is_alphabetic() && c != '_') {
+        if key.trim().chars().any(|c| !c.is_alphabetic() && c != '_') {
             return Some(Warning {
                 message: self.warning.message.replace("{}", key),
             });
@@ -57,6 +53,17 @@ mod tests {
     }
 
     #[test]
+    fn failing_with_whitepsace_run() {
+        let checker = IncorrectDelimiterChecker::default();
+        let line = &LineEntry {
+            number: 1,
+            raw_string: String::from("DEBUG HTTP=true"),
+        };
+        let expected = Some(Warning::new("The DEBUG HTTP key has incorrect delimiter"));
+        assert_eq!(expected, checker.run(line));
+    }
+
+    #[test]
     fn unformated_run() {
         let checker = IncorrectDelimiterChecker::default();
         let line = &LineEntry {
@@ -72,6 +79,16 @@ mod tests {
         let line = &LineEntry {
             number: 1,
             raw_string: String::from(" DEBUG_HTTP=true"),
+        };
+        assert_eq!(None, checker.run(line));
+    }
+
+    #[test]
+    fn trailing_space_run() {
+        let checker = IncorrectDelimiterChecker::default();
+        let line = &LineEntry {
+            number: 1,
+            raw_string: String::from("DEBUG_HTTP =true"),
         };
         assert_eq!(None, checker.run(line));
     }


### PR DESCRIPTION
Addresses issue: #8 
I had to change the `checkout` function in src/check.rs - In order for different types to be bundled into a `Vec`, it needs to be wrapped in a `Box` which implements the `Check` trait.