### PR TITLE
Make leading space detector more robust and aware of allowed chars 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add skipping of commented or empty lines [#37](https://github.com/mgrachev/dotenv-linter/pull/37) ([@mstruebing](https://github.com/mstruebing))
 
 ### 🔧 Changed
+- Rename `leading_space` to `leading_character` and check for allowed chars [#63](https://github.com/mgrachev/dotenv-linter/pull/63) ([@mstruebing](https://github.com/mstruebing))
 - Remove multiple checks of the same file [#62](https://github.com/mgrachev/dotenv-linter/pull/62) ([@mstruebing](https://github.com/mstruebing))
 - Add mutability support for checks [#52](https://github.com/mgrachev/dotenv-linter/pull/52)
 

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ FOO=BAR
 
 ### Leading character
 
-Detects if a line starts with an allowed character (characters from a to z and `_` (underscore) are allowed)
+Detects if a line starts with an unallowed character (characters from `A` to `Z` and `_` (underscore) are allowed):
 
 ```env
 ❌Wrong

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ By default, `dotenv-linter` checks all files with the `.env` prefix. For example
 
 ```bash
 $ dotenv-linter
-.env:1 Leading space detected
+.env:1 Invalid leading character detected
 .env:2 The FOO-BAR key has incorrect delimiter
 .env:3 The FOo_BAR key should be in uppercase
 .env:4 The line has spaces around equal sign
@@ -68,7 +68,7 @@ you can use the argument `--include FILE_NAME` or its short version `-i FILE_NAM
 
 ```bash
 $ dotenv-linter -i test.env --include .my-env-file
-.env:1 Leading space detected
+.env:1 Invalid leading character detected
 test.env:2 The FOO-BAR key has incorrect delimiter
 .my-env-file:3 The line has spaces around equal sign
 ```
@@ -128,9 +128,9 @@ FOO=
 FOO=BAR
 ```
 
-### Leading space
+### Leading character
 
-Detects if a line starts with a space or a tab character:
+Detects if a line starts with an allowed character (characters from a to z and `_` (underscore) are allowed)
 
 ```env
 ❌Wrong

--- a/src/checks.rs
+++ b/src/checks.rs
@@ -3,7 +3,7 @@ use crate::common::*;
 mod duplicated_keys;
 mod incorrect_delimiter;
 mod key_without_value;
-mod leading_space;
+mod leading_character;
 mod lowercase_key;
 mod spaces_around_equal;
 mod unordered_keys;
@@ -18,7 +18,7 @@ fn checklist() -> Vec<Box<dyn Check>> {
     vec![
         Box::new(duplicated_keys::DuplicatedKeysChecker::default()),
         Box::new(incorrect_delimiter::IncorrectDelimiterChecker::default()),
-        Box::new(leading_space::LeadingSpaceChecker::default()),
+        Box::new(leading_character::LeadingCharacterChecker::default()),
         Box::new(key_without_value::KeyWithoutValueChecker::default()),
         Box::new(lowercase_key::LowercaseKeyChecker::default()),
         Box::new(spaces_around_equal::SpacesAroundEqualChecker::default()),

--- a/src/checks/leading_character.rs
+++ b/src/checks/leading_character.rs
@@ -1,11 +1,11 @@
 use crate::checks::Check;
 use crate::common::*;
 
-pub(crate) struct LeadingSpaceChecker {
+pub(crate) struct LeadingCharacterChecker {
     template: String,
 }
 
-impl Default for LeadingSpaceChecker {
+impl Default for LeadingCharacterChecker {
     fn default() -> Self {
         Self {
             template: String::from("Invalid leading character detected"),
@@ -13,7 +13,7 @@ impl Default for LeadingSpaceChecker {
     }
 }
 
-impl Check for LeadingSpaceChecker {
+impl Check for LeadingCharacterChecker {
     fn run(&mut self, line: LineEntry) -> Option<Warning> {
         if line
             .raw_string
@@ -34,7 +34,7 @@ mod tests {
 
     #[test]
     fn normal() {
-        let mut checker = LeadingSpaceChecker::default();
+        let mut checker = LeadingCharacterChecker::default();
         let line = LineEntry {
             number: 1,
             file_name: String::from(".env"),
@@ -45,7 +45,7 @@ mod tests {
 
     #[test]
     fn leading_underscore() {
-        let mut checker = LeadingSpaceChecker::default();
+        let mut checker = LeadingCharacterChecker::default();
         let line = LineEntry {
             number: 1,
             file_name: String::from(".env"),
@@ -56,7 +56,7 @@ mod tests {
 
     #[test]
     fn leading_dot() {
-        let mut checker = LeadingSpaceChecker::default();
+        let mut checker = LeadingCharacterChecker::default();
         let line = LineEntry {
             number: 1,
             file_name: String::from(".env"),
@@ -70,7 +70,7 @@ mod tests {
 
     #[test]
     fn leading_asterisk() {
-        let mut checker = LeadingSpaceChecker::default();
+        let mut checker = LeadingCharacterChecker::default();
         let line = LineEntry {
             number: 1,
             file_name: String::from(".env"),
@@ -84,7 +84,7 @@ mod tests {
 
     #[test]
     fn leading_number() {
-        let mut checker = LeadingSpaceChecker::default();
+        let mut checker = LeadingCharacterChecker::default();
         let line = LineEntry {
             number: 1,
             file_name: String::from(".env"),
@@ -98,7 +98,7 @@ mod tests {
 
     #[test]
     fn leading_space() {
-        let mut checker = LeadingSpaceChecker::default();
+        let mut checker = LeadingCharacterChecker::default();
         let line = LineEntry {
             number: 1,
             file_name: String::from(".env"),
@@ -110,7 +110,7 @@ mod tests {
 
     #[test]
     fn two_leading_spaces() {
-        let mut checker = LeadingSpaceChecker::default();
+        let mut checker = LeadingCharacterChecker::default();
         let line = LineEntry {
             number: 1,
             file_name: String::from(".env"),
@@ -122,7 +122,7 @@ mod tests {
 
     #[test]
     fn leading_tab() {
-        let mut checker = LeadingSpaceChecker::default();
+        let mut checker = LeadingCharacterChecker::default();
         let line = LineEntry {
             number: 1,
             file_name: String::from(".env"),

--- a/src/checks/leading_space.rs
+++ b/src/checks/leading_space.rs
@@ -8,7 +8,7 @@ pub(crate) struct LeadingSpaceChecker {
 impl Default for LeadingSpaceChecker {
     fn default() -> Self {
         Self {
-            template: String::from("Leading space detected"),
+            template: String::from("Invalid leading character detected"),
         }
     }
 }
@@ -30,7 +30,7 @@ impl Check for LeadingSpaceChecker {
 mod tests {
     use super::*;
 
-    const MESSAGE: &str = "Leading space detected";
+    const MESSAGE: &str = "Invalid leading character detected";
 
     #[test]
     fn normal() {


### PR DESCRIPTION
I created this proof of concept to use a regular expression in the leading space checker.
However, as I'm not the maintainer I don't know if this is the way where this project wants to go.

If you would go for it we have two options I can currently see:

* rename the leading space checker to something it really reflects (leading character checker or something)
* Combine some other checkers which only act on one line also into a regex and one checker (for example, I think it would be very easy to combine the leading space, spaces around equal, and uppercase key checker, quick and dirty and not fully functional: `^[#A-Z_]*=.*`

closes #56