### PR TITLE
Add support for specified directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add the ability to include files to check [#48](https://github.com/mgrachev/dotenv-linter/pull/48)
 - Add check: Spaces around equal sign [#35](https://github.com/mgrachev/dotenv-linter/pull/35) ([@artem-russkikh](https://github.com/artem-russkikh))
 - Add skipping of commented or empty lines [#37](https://github.com/mgrachev/dotenv-linter/pull/37) ([@mstruebing](https://github.com/mstruebing))
+- Add exit with the code 1 on warnings found [#58](https://github.com/mgrachev/dotenv-linter/pull/58) (@[Louis-Lesage](https://github.com/Louis-Lesage))
 
 ### 🔧 Changed
 - Add mutability support for checks [#52](https://github.com/mgrachev/dotenv-linter/pull/52)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ use std::fs;
 use std::fs::File;
 use std::io::{BufRead, BufReader, Error};
 use std::path::PathBuf;
+use std::process;
 
 mod checks;
 
@@ -46,7 +47,7 @@ pub fn run(matches: clap::ArgMatches) -> Result<(), Error> {
 
         let warnings = checks::run(FileEntry { lines });
         warnings.iter().for_each(|w| println!("{}", w));
-        // TODO: Exit with the code 1 if there is at least one warning
+        if warnings.len() > 0 { process::exit(1); }
     }
 
     Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,7 +47,9 @@ pub fn run(matches: clap::ArgMatches) -> Result<(), Error> {
 
         let warnings = checks::run(FileEntry { lines });
         warnings.iter().for_each(|w| println!("{}", w));
-        if warnings.len() > 0 { process::exit(1); }
+        if !warnings.is_empty() {
+            process::exit(1);
+        }
     }
 
     Ok(())


### PR DESCRIPTION
I've changed the `dotenv_files` function to accept a directory path and added the cli argument -p or --path to specify the directory where to run. 

If there is no argument -p, the program use the current directory.