### PR TITLE
Add support for specified directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### 🚀 Added
+- Add the ability to specify the directory where to run [#65](https://github.com/mgrachev/dotenv-linter/pull/65) ([@Louis-Lesage](https://github.com/Louis-Lesage))
 - Add check: Duplicated keys [#33](https://github.com/mgrachev/dotenv-linter/pull/33) ([@mstruebing](https://github.com/mstruebing))
 - Add exit with the code 1 on warnings found [#58](https://github.com/mgrachev/dotenv-linter/pull/58) ([@Louis-Lesage](https://github.com/Louis-Lesage))
 - Add exclude argument to exclude specific files [#49](https://github.com/mgrachev/dotenv-linter/pull/49) ([@mstruebing](https://github.com/mstruebing))
 - Add the ability to include files to check [#48](https://github.com/mgrachev/dotenv-linter/pull/48)
 - Add check: Spaces around equal sign [#35](https://github.com/mgrachev/dotenv-linter/pull/35) ([@artem-russkikh](https://github.com/artem-russkikh))
 - Add skipping of commented or empty lines [#37](https://github.com/mgrachev/dotenv-linter/pull/37) ([@mstruebing](https://github.com/mstruebing))
+
 
 ### 🔧 Changed
 - Add mutability support for checks [#52](https://github.com/mgrachev/dotenv-linter/pull/52)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add check: Spaces around equal sign [#35](https://github.com/mgrachev/dotenv-linter/pull/35) ([@artem-russkikh](https://github.com/artem-russkikh))
 - Add skipping of commented or empty lines [#37](https://github.com/mgrachev/dotenv-linter/pull/37) ([@mstruebing](https://github.com/mstruebing))
 
-
 ### 🔧 Changed
 - Add mutability support for checks [#52](https://github.com/mgrachev/dotenv-linter/pull/52)
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,6 @@ you can use the argument `--path DIRECTORY_PATH` or its short version `-p DIRECT
 $ dotenv-linter -p /directory/where/to/run
 ```
 
-
 ## ✅ Checks
 
 ### Duplicated Keys

--- a/README.md
+++ b/README.md
@@ -79,6 +79,14 @@ you can use the argument `--exclude FILE_NAME` or its short version `-e FILE_NAM
 $ dotenv-linter -e .env --exclude .env.test
 ```
 
+If you want to specify the directory where to run dotenv-linter,
+you can use the argument `--path DIRECTORY_PATH` or its short version `-p DIRECTORY_PATH`:
+
+```bash
+$ dotenv-linter -p /directory/where/to/run
+```
+
+
 ## ✅ Checks
 
 ### Duplicated Keys

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,10 +37,15 @@ impl LineEntry {
 }
 
 pub fn run(matches: clap::ArgMatches) -> Result<(), Error> {
-    let paths = dotenv_files(matches)?;
+    let dir_path = match matches.value_of("path") {
+        Some(fpath) => PathBuf::from(fpath),
+        None => env::current_dir()?,
+    };
+
+    let file_paths = dotenv_files(matches, dir_path)?;
 
     let mut warnings: Vec<Warning> = Vec::new();
-    for path in paths {
+    for path in file_paths {
         let f = File::open(&path)?;
         let reader = BufReader::new(f);
         let file_name = match path.file_name() {
@@ -73,9 +78,8 @@ pub fn run(matches: clap::ArgMatches) -> Result<(), Error> {
     Ok(())
 }
 
-fn dotenv_files(matches: clap::ArgMatches) -> Result<Vec<PathBuf>, Error> {
-    let current_dir = env::current_dir()?;
-    let entries = current_dir.read_dir()?;
+fn dotenv_files(matches: clap::ArgMatches, dir_path: PathBuf) -> Result<Vec<PathBuf>, Error> {
+    let entries = dir_path.read_dir()?;
 
     // TODO: Use HashSet to store unique paths
     // https://doc.rust-lang.org/std/collections/struct.HashSet.html

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,6 +28,15 @@ fn main() {
                 .multiple(true)
                 .takes_value(true),
         )
+        .arg(
+            Arg::with_name("path")
+                .short("p")
+                .long("path")
+                .value_name("DIRECTORY_PATH")
+                .help("Specify the path of the directory where to run dotenv-linter")
+                .multiple(false)
+                .takes_value(true),
+        )
         .get_matches();
 
     if let Err(e) = dotenv_linter::run(matches) {


### PR DESCRIPTION
Added cli argument --path or -p where you specify the path of the directory where you want dotenv-linter to run.

If there is no argument -p, the program use the current directory.