### PR TITLE
Extend the default include files pattern

### DIFF
--- a/src/checks.rs
+++ b/src/checks.rs
@@ -24,11 +24,11 @@ fn checklist() -> Vec<Box<dyn Check>> {
     ]
 }
 
-pub fn run(file: FileEntry) -> Vec<Warning> {
+pub fn run(lines: Vec<LineEntry>) -> Vec<Warning> {
     let mut checks = checklist();
     let mut warnings: Vec<Warning> = Vec::new();
 
-    for line in file.lines {
+    for line in lines {
         // TODO: Move to a method
         // A comment or empty line should just be skipped
         let trimmed_string = line.raw_string.trim();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,6 +90,7 @@ impl<'a> DotenvLinter<'a> {
     }
 
     /// Returns `Result<Vec<FileEntry>` of files with the the `.env` prefix
+    #[allow(clippy::redundant_closure)]
     fn dotenv_files(&self, dir_path: PathBuf) -> Result<Vec<FileEntry>, Error> {
         let entries = dir_path.read_dir()?;
 


### PR DESCRIPTION
This PR fixes some issues:
* Extend the `.env` pattern to include the `*.env` files to check;
* Replace back `HashSet` to `Vector` to keep files' order;
* Remove duplicate file name definition;
* Add test coverage for the `FileEntry` struct.
