### PR TITLE
Use Line.get_key in all checkers

### DIFF
--- a/src/checks/incorrect_delimiter.rs
+++ b/src/checks/incorrect_delimiter.rs
@@ -15,10 +15,9 @@ impl Default for IncorrectDelimiterChecker {
 
 impl Check for IncorrectDelimiterChecker {
     fn run(&mut self, line: LineEntry) -> Option<Warning> {
-        let eq_index = line.raw_string.find('=')?;
-        let key = line.raw_string.get(0..eq_index)?;
+        let key = line.get_key()?;
         if key.trim().chars().any(|c| !c.is_alphabetic() && c != '_') {
-            return Some(Warning::new(line.clone(), self.template.replace("{}", key)));
+            return Some(Warning::new(line.clone(), self.template.replace("{}", &key)));
         }
 
         None

--- a/src/checks/incorrect_delimiter.rs
+++ b/src/checks/incorrect_delimiter.rs
@@ -17,7 +17,7 @@ impl Check for IncorrectDelimiterChecker {
     fn run(&mut self, line: LineEntry) -> Option<Warning> {
         let key = line.get_key()?;
         if key.trim().chars().any(|c| !c.is_alphabetic() && c != '_') {
-            return Some(Warning::new(line.clone(), self.template.replace("{}", &key)));
+            return Some(Warning::new(line, self.template.replace("{}", &key)));
         }
 
         None

--- a/src/checks/lowercase_key.rs
+++ b/src/checks/lowercase_key.rs
@@ -15,12 +15,11 @@ impl Default for LowercaseKeyChecker {
 
 impl Check for LowercaseKeyChecker {
     fn run(&mut self, line: LineEntry) -> Option<Warning> {
-        let line_str: Vec<&str> = line.raw_string.split('=').collect();
-        let key = line_str[0];
+        let key = line.get_key()?;
         if key.to_uppercase() == key {
             None
         } else {
-            Some(Warning::new(line.clone(), self.template.replace("{}", key)))
+            Some(Warning::new(line.clone(), self.template.replace("{}", &key)))
         }
     }
 }

--- a/src/checks/lowercase_key.rs
+++ b/src/checks/lowercase_key.rs
@@ -19,7 +19,7 @@ impl Check for LowercaseKeyChecker {
         if key.to_uppercase() == key {
             None
         } else {
-            Some(Warning::new(line.clone(), self.template.replace("{}", &key)))
+            Some(Warning::new(line, self.template.replace("{}", &key)))
         }
     }
 }


### PR DESCRIPTION
* Changed IncorrectDelimiterChecker and LowercaseKeyChecker to use Line.get_key method