### PR TITLE
[#102] Remove unused args

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,30 +26,12 @@ fn get_args(current_dir: &str) -> clap::ArgMatches {
                 .multiple(true),
         )
         .arg(
-            Arg::with_name("include")
-                .short("i")
-                .long("include")
-                .value_name("FILE_NAME")
-                .help("Includes files to check")
-                .multiple(true)
-                .takes_value(true),
-        )
-        .arg(
             Arg::with_name("exclude")
                 .short("e")
                 .long("exclude")
                 .value_name("FILE_NAME")
                 .help("Excludes files from check")
                 .multiple(true)
-                .takes_value(true),
-        )
-        .arg(
-            Arg::with_name("path")
-                .short("p")
-                .long("path")
-                .value_name("DIRECTORY_PATH")
-                .help("Specify the path of the directory where to run dotenv-linter")
-                .multiple(false)
                 .takes_value(true),
         )
         .get_matches()


### PR DESCRIPTION
Removes the unused args : `--include` and `--path`

Close #102 