### PR TITLE
Fix #103: Remove the unwrap method while working with current directory

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,17 @@
+<!--
+Thank you for your pull request. Please provide a description above and review
+the requirements below.
+
+Bug fixes and new features should include tests.
+-->
+
+<!-- _Please make sure to review and check all of these items:_ -->
+
+#### ✔ Checklist:
+<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
+
+- [ ] This PR has been added to [CHANGELOG.md](https://github.com/mgrachev/dotenv-linter/blob/master/CHANGELOG.md) (at the top of the list);
+- [ ] Tests for the changes have been added (for bug fixes / features);
+- [ ] Docs have been added / updated (for bug fixes / features).
+
+<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### 🚀 Added
 
 ### 🔧 Changed
+- Use reference for the LineEntry as part of the run method for checks [#111](https://github.com/mgrachev/dotenv-linter/pull/111) ([@TamasFlorin](https://github.com/TamasFlorin))
 - New CLI API: Ability to check multiple directories [#99](https://github.com/mgrachev/dotenv-linter/pull/99)
 - Add exit with the code 0 when there are no warnings [#105](https://github.com/mgrachev/dotenv-linter/pull/105) ([@simPod](https://github.com/simPod))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### 🔧 Changed
 - New CLI API: Ability to check multiple directories [#99](https://github.com/mgrachev/dotenv-linter/pull/99)
+- Add exit with the code 0 when there are no warnings [#105](https://github.com/mgrachev/dotenv-linter/pull/105) ([@simPod](https://github.com/simPod))
 
 ## [v1.1.2] - 2020-03-13
 ### 🔧 Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Use reference for the LineEntry as part of the run method for checks [#111](https://github.com/mgrachev/dotenv-linter/pull/111) ([@TamasFlorin](https://github.com/TamasFlorin))
 - New CLI API: Ability to check multiple directories [#99](https://github.com/mgrachev/dotenv-linter/pull/99)
 - Add exit with the code 0 when there are no warnings [#105](https://github.com/mgrachev/dotenv-linter/pull/105) ([@simPod](https://github.com/simPod))
+- Remove the unwrap method and use platform native OsString to fetch the information about current directory [#109](https://github.com/mgrachev/dotenv-linter/pull/109) ([@kanapuli](https://github.com/kanapuli))
 
 ## [v1.1.2] - 2020-03-13
 ### 🔧 Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### 🚀 Added
 
 ### 🔧 Changed
+- Use HashSet for DuplicateKeyChecker [#113](https://github.com/mgrachev/dotenv-linter/pull/113) ([@TamasFlorin](https://github.com/TamasFlorin))
 - Use reference for the LineEntry as part of the run method for checks [#111](https://github.com/mgrachev/dotenv-linter/pull/111) ([@TamasFlorin](https://github.com/TamasFlorin))
 - New CLI API: Ability to check multiple directories [#99](https://github.com/mgrachev/dotenv-linter/pull/99)
 - Add exit with the code 0 when there are no warnings [#105](https://github.com/mgrachev/dotenv-linter/pull/105) ([@simPod](https://github.com/simPod))

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,10 +54,10 @@ impl Default for ExampleChecker {
 }
 
 impl Check for ExampleChecker {
-    fn run(&mut self, line: LineEntry) -> Option<Warning> {
+    fn run(&mut self, line: &LineEntry) -> Option<Warning> {
         // Write your check logic here...
         if line.raw_string.starts_with("EXAMPLE") {
-            Some(Warning::new(line, self.template.clone()))
+            Some(Warning::new(line.clone(), self.template.clone()))
         } else {
             None
         }
@@ -93,7 +93,7 @@ mod tests {
             raw_string: String::from("EXAMPLE=true"),
         };
         let expected = Some(Warning::new(line.clone(), String::from("Example detected")));
-        assert_eq!(expected, checker.run(line));
+        assert_eq!(expected, checker.run(&line));
     }
 }
 ```

--- a/src/checks.rs
+++ b/src/checks.rs
@@ -10,7 +10,7 @@ mod unordered_keys;
 
 // This trait is used for checks which needs to know of only a single line
 trait Check {
-    fn run(&mut self, line: LineEntry) -> Option<Warning>;
+    fn run(&mut self, line: &LineEntry) -> Option<Warning>;
 }
 
 // Checklist for checks which needs to know of only a single line
@@ -36,8 +36,7 @@ pub fn run(lines: Vec<LineEntry>) -> Vec<Warning> {
         }
 
         for ch in &mut checks {
-            // TODO: Use a reference instead of the clone method
-            if let Some(warning) = ch.run(line.clone()) {
+            if let Some(warning) = ch.run(&line) {
                 warnings.push(warning);
             }
         }

--- a/src/checks/duplicated_keys.rs
+++ b/src/checks/duplicated_keys.rs
@@ -16,11 +16,14 @@ impl Default for DuplicatedKeysChecker {
 }
 
 impl Check for DuplicatedKeysChecker {
-    fn run(&mut self, line: LineEntry) -> Option<Warning> {
+    fn run(&mut self, line: &LineEntry) -> Option<Warning> {
         let key = line.get_key()?;
 
         if self.keys.contains(&key) {
-            return Some(Warning::new(line, self.template.replace("{}", &key)));
+            return Some(Warning::new(
+                line.clone(),
+                self.template.replace("{}", &key),
+            ));
         }
 
         self.keys.push(key);
@@ -38,7 +41,7 @@ mod tests {
 
         for assert in asserts {
             let (input, output) = assert;
-            assert_eq!(checker.run(input), output);
+            assert_eq!(checker.run(&input), output);
         }
     }
 

--- a/src/checks/duplicated_keys.rs
+++ b/src/checks/duplicated_keys.rs
@@ -1,15 +1,16 @@
 use crate::checks::Check;
 use crate::common::*;
+use std::collections::HashSet;
 
 pub(crate) struct DuplicatedKeysChecker {
     template: String,
-    keys: Vec<String>,
+    keys: HashSet<String>,
 }
 
 impl Default for DuplicatedKeysChecker {
     fn default() -> Self {
         Self {
-            keys: Vec::new(),
+            keys: HashSet::new(),
             template: String::from("The {} key is duplicated"),
         }
     }
@@ -26,7 +27,7 @@ impl Check for DuplicatedKeysChecker {
             ));
         }
 
-        self.keys.push(key);
+        self.keys.insert(key);
         None
     }
 }

--- a/src/checks/incorrect_delimiter.rs
+++ b/src/checks/incorrect_delimiter.rs
@@ -14,10 +14,13 @@ impl Default for IncorrectDelimiterChecker {
 }
 
 impl Check for IncorrectDelimiterChecker {
-    fn run(&mut self, line: LineEntry) -> Option<Warning> {
+    fn run(&mut self, line: &LineEntry) -> Option<Warning> {
         let key = line.get_key()?;
         if key.trim().chars().any(|c| !c.is_alphanumeric() && c != '_') {
-            return Some(Warning::new(line, self.template.replace("{}", &key)));
+            return Some(Warning::new(
+                line.clone(),
+                self.template.replace("{}", &key),
+            ));
         }
 
         None
@@ -37,7 +40,7 @@ mod tests {
             file_path: PathBuf::from(".env"),
             raw_string: String::from("FOO_BAR=FOOBAR"),
         };
-        assert_eq!(None, checker.run(line));
+        assert_eq!(None, checker.run(&line));
     }
 
     #[test]
@@ -48,7 +51,7 @@ mod tests {
             file_path: PathBuf::from(".env"),
             raw_string: String::from("F1OO=BAR"),
         };
-        assert_eq!(None, checker.run(line));
+        assert_eq!(None, checker.run(&line));
     }
 
     #[test]
@@ -63,7 +66,7 @@ mod tests {
             line.clone(),
             String::from("The FOO-BAR key has incorrect delimiter"),
         ));
-        assert_eq!(expected, checker.run(line));
+        assert_eq!(expected, checker.run(&line));
     }
 
     #[test]
@@ -78,7 +81,7 @@ mod tests {
             line.clone(),
             String::from("The FOO BAR key has incorrect delimiter"),
         ));
-        assert_eq!(expected, checker.run(line));
+        assert_eq!(expected, checker.run(&line));
     }
 
     #[test]
@@ -89,7 +92,7 @@ mod tests {
             file_path: PathBuf::from(".env"),
             raw_string: String::from("FOO-BAR"),
         };
-        assert_eq!(None, checker.run(line));
+        assert_eq!(None, checker.run(&line));
     }
 
     #[test]
@@ -100,7 +103,7 @@ mod tests {
             file_path: PathBuf::from(".env"),
             raw_string: String::from(" FOO=FOOBAR"),
         };
-        assert_eq!(None, checker.run(line));
+        assert_eq!(None, checker.run(&line));
     }
 
     #[test]
@@ -111,7 +114,7 @@ mod tests {
             file_path: PathBuf::from(".env"),
             raw_string: String::from("FOO_BAR =FOOBAR"),
         };
-        assert_eq!(None, checker.run(line));
+        assert_eq!(None, checker.run(&line));
     }
 
     #[test]
@@ -122,7 +125,7 @@ mod tests {
             file_path: PathBuf::from(".env"),
             raw_string: String::from(""),
         };
-        assert_eq!(None, checker.run(line));
+        assert_eq!(None, checker.run(&line));
     }
 
     #[test]
@@ -133,6 +136,6 @@ mod tests {
             file_path: PathBuf::from(".env"),
             raw_string: String::from("F=BAR"),
         };
-        assert_eq!(None, checker.run(line));
+        assert_eq!(None, checker.run(&line));
     }
 }

--- a/src/checks/key_without_value.rs
+++ b/src/checks/key_without_value.rs
@@ -14,7 +14,7 @@ impl Default for KeyWithoutValueChecker {
 }
 
 impl Check for KeyWithoutValueChecker {
-    fn run(&mut self, line: LineEntry) -> Option<Warning> {
+    fn run(&mut self, line: &LineEntry) -> Option<Warning> {
         if !line.raw_string.contains('=') {
             Some(Warning::new(
                 line.clone(),
@@ -39,7 +39,7 @@ mod tests {
             file_path: PathBuf::from(".env"),
             raw_string: String::from("FOO=BAR"),
         };
-        assert_eq!(None, checker.run(line));
+        assert_eq!(None, checker.run(&line));
     }
 
     #[test]
@@ -50,7 +50,7 @@ mod tests {
             file_path: PathBuf::from(".env"),
             raw_string: String::from("FOO="),
         };
-        assert_eq!(None, checker.run(line));
+        assert_eq!(None, checker.run(&line));
     }
 
     #[test]
@@ -65,6 +65,6 @@ mod tests {
             line.clone(),
             String::from("The FOO key should be with a value or have an equal sign"),
         ));
-        assert_eq!(expected, checker.run(line));
+        assert_eq!(expected, checker.run(&line));
     }
 }

--- a/src/checks/leading_character.rs
+++ b/src/checks/leading_character.rs
@@ -14,14 +14,14 @@ impl Default for LeadingCharacterChecker {
 }
 
 impl Check for LeadingCharacterChecker {
-    fn run(&mut self, line: LineEntry) -> Option<Warning> {
+    fn run(&mut self, line: &LineEntry) -> Option<Warning> {
         if line
             .raw_string
             .starts_with(|c: char| c.is_alphabetic() || c == '_')
         {
             None
         } else {
-            Some(Warning::new(line, self.template.clone()))
+            Some(Warning::new(line.clone(), self.template.clone()))
         }
     }
 }
@@ -41,7 +41,7 @@ mod tests {
             file_path: PathBuf::from(".env"),
             raw_string: String::from("FOO=BAR"),
         };
-        assert_eq!(None, checker.run(line));
+        assert_eq!(None, checker.run(&line));
     }
 
     #[test]
@@ -52,7 +52,7 @@ mod tests {
             file_path: PathBuf::from(".env"),
             raw_string: String::from("_FOO=BAR"),
         };
-        assert_eq!(None, checker.run(line));
+        assert_eq!(None, checker.run(&line));
     }
 
     #[test]
@@ -65,7 +65,7 @@ mod tests {
         };
         assert_eq!(
             Some(Warning::new(line.clone(), MESSAGE.to_string())),
-            checker.run(line)
+            checker.run(&line)
         );
     }
 
@@ -79,7 +79,7 @@ mod tests {
         };
         assert_eq!(
             Some(Warning::new(line.clone(), MESSAGE.to_string())),
-            checker.run(line)
+            checker.run(&line)
         );
     }
 
@@ -93,7 +93,7 @@ mod tests {
         };
         assert_eq!(
             Some(Warning::new(line.clone(), MESSAGE.to_string())),
-            checker.run(line)
+            checker.run(&line)
         );
     }
 
@@ -106,7 +106,7 @@ mod tests {
             raw_string: String::from(" FOO=BAR"),
         };
         let expected = Some(Warning::new(line.clone(), MESSAGE.to_string()));
-        assert_eq!(expected, checker.run(line));
+        assert_eq!(expected, checker.run(&line));
     }
 
     #[test]
@@ -118,7 +118,7 @@ mod tests {
             raw_string: String::from("  FOO=BAR"),
         };
         let expected = Some(Warning::new(line.clone(), MESSAGE.to_string()));
-        assert_eq!(expected, checker.run(line));
+        assert_eq!(expected, checker.run(&line));
     }
 
     #[test]
@@ -130,6 +130,6 @@ mod tests {
             raw_string: String::from("\tFOO=BAR"),
         };
         let expected = Some(Warning::new(line.clone(), MESSAGE.to_string()));
-        assert_eq!(expected, checker.run(line));
+        assert_eq!(expected, checker.run(&line));
     }
 }

--- a/src/checks/lowercase_key.rs
+++ b/src/checks/lowercase_key.rs
@@ -14,12 +14,15 @@ impl Default for LowercaseKeyChecker {
 }
 
 impl Check for LowercaseKeyChecker {
-    fn run(&mut self, line: LineEntry) -> Option<Warning> {
+    fn run(&mut self, line: &LineEntry) -> Option<Warning> {
         let key = line.get_key()?;
         if key.to_uppercase() == key {
             None
         } else {
-            Some(Warning::new(line, self.template.replace("{}", &key)))
+            Some(Warning::new(
+                line.clone(),
+                self.template.replace("{}", &key),
+            ))
         }
     }
 }
@@ -37,7 +40,7 @@ mod tests {
             file_path: PathBuf::from(".env"),
             raw_string: String::from("FOO=BAR"),
         };
-        assert_eq!(None, checker.run(line));
+        assert_eq!(None, checker.run(&line));
     }
 
     #[test]
@@ -52,7 +55,7 @@ mod tests {
             line.clone(),
             String::from("The foo_bar key should be in uppercase"),
         ));
-        assert_eq!(expected, checker.run(line));
+        assert_eq!(expected, checker.run(&line));
     }
 
     #[test]
@@ -67,6 +70,6 @@ mod tests {
             line.clone(),
             String::from("The FOo_BAR key should be in uppercase"),
         ));
-        assert_eq!(expected, checker.run(line));
+        assert_eq!(expected, checker.run(&line));
     }
 }

--- a/src/checks/spaces_around_equal.rs
+++ b/src/checks/spaces_around_equal.rs
@@ -14,12 +14,12 @@ impl Default for SpacesAroundEqualChecker {
 }
 
 impl Check for SpacesAroundEqualChecker {
-    fn run(&mut self, line: LineEntry) -> Option<Warning> {
+    fn run(&mut self, line: &LineEntry) -> Option<Warning> {
         let line_splitted = line.raw_string.split('=').collect::<Vec<&str>>();
 
         if let [key, value] = &line_splitted[..] {
             if key.ends_with(' ') || value.starts_with(' ') {
-                return Some(Warning::new(line, self.template.clone()));
+                return Some(Warning::new(line.clone(), self.template.clone()));
             }
         }
 
@@ -42,7 +42,7 @@ mod tests {
             file_path: PathBuf::from(".env"),
             raw_string: String::from("DEBUG_HTTP=true"),
         };
-        assert_eq!(None, checker.run(line));
+        assert_eq!(None, checker.run(&line));
     }
 
     #[test]
@@ -53,7 +53,7 @@ mod tests {
             file_path: PathBuf::from(".env"),
             raw_string: String::from(" DEBUG_HTTP=true"),
         };
-        assert_eq!(None, checker.run(line));
+        assert_eq!(None, checker.run(&line));
     }
 
     #[test]
@@ -64,7 +64,7 @@ mod tests {
             file_path: PathBuf::from(".env"),
             raw_string: String::from("DEBUG_HTTP=true "),
         };
-        assert_eq!(None, checker.run(line));
+        assert_eq!(None, checker.run(&line));
     }
 
     #[test]
@@ -75,7 +75,7 @@ mod tests {
             file_path: PathBuf::from(".env"),
             raw_string: String::from(""),
         };
-        assert_eq!(None, checker.run(line));
+        assert_eq!(None, checker.run(&line));
     }
 
     #[test]
@@ -86,7 +86,7 @@ mod tests {
             file_path: PathBuf::from(".env"),
             raw_string: String::from("DEBUG_HTTP true"),
         };
-        assert_eq!(None, checker.run(line));
+        assert_eq!(None, checker.run(&line));
     }
 
     #[test]
@@ -98,7 +98,7 @@ mod tests {
             raw_string: String::from("DEBUG-HTTP = true"),
         };
         let expected = Some(Warning::new(line.clone(), MESSAGE.to_string()));
-        assert_eq!(expected, checker.run(line));
+        assert_eq!(expected, checker.run(&line));
     }
 
     #[test]
@@ -110,7 +110,7 @@ mod tests {
             raw_string: String::from("DEBUG-HTTP =true"),
         };
         let expected = Some(Warning::new(line.clone(), MESSAGE.to_string()));
-        assert_eq!(expected, checker.run(line));
+        assert_eq!(expected, checker.run(&line));
     }
 
     #[test]
@@ -122,6 +122,6 @@ mod tests {
             raw_string: String::from("DEBUG-HTTP= true"),
         };
         let expected = Some(Warning::new(line.clone(), MESSAGE.to_string()));
-        assert_eq!(expected, checker.run(line));
+        assert_eq!(expected, checker.run(&line));
     }
 }

--- a/src/checks/unordered_keys.rs
+++ b/src/checks/unordered_keys.rs
@@ -16,7 +16,7 @@ impl Default for UnorderedKeysChecker {
 }
 
 impl Check for UnorderedKeysChecker {
-    fn run(&mut self, line: LineEntry) -> Option<Warning> {
+    fn run(&mut self, line: &LineEntry) -> Option<Warning> {
         let key = line.get_key()?;
         self.keys.push(key.clone());
         let mut sorted_keys = self.keys.clone();
@@ -33,7 +33,7 @@ impl Check for UnorderedKeysChecker {
             let another_key = sorted_keys[index + 1].clone();
 
             let warning = Warning::new(
-                line,
+                line.clone(),
                 self.template
                     .replace("{1}", &key)
                     .replace("{2}", &another_key),
@@ -55,7 +55,7 @@ mod tests {
 
         for assert in asserts {
             let (input, output) = assert;
-            assert_eq!(checker.run(input), output);
+            assert_eq!(checker.run(&input), output);
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@ fn get_args(current_dir: &OsStr) -> clap::ArgMatches {
             Arg::with_name("input")
                 .help("files or paths")
                 .index(1)
-                .default_value(current_dir.to_str().unwrap())
+                .default_value_os(current_dir)
                 .required(true)
                 .multiple(true),
         )

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,11 +7,12 @@ use std::fs;
 use std::fs::File;
 use std::io::{BufRead, BufReader};
 use std::path::PathBuf;
+use std::ffi::OsStr;
 
 mod checks;
 mod common;
 
-fn get_args(current_dir: &str) -> clap::ArgMatches {
+fn get_args(current_dir: &OsStr) -> clap::ArgMatches {
     clap::App::new(env!("CARGO_PKG_NAME"))
         .about(env!("CARGO_PKG_DESCRIPTION"))
         .author(env!("CARGO_PKG_AUTHORS"))
@@ -21,7 +22,7 @@ fn get_args(current_dir: &str) -> clap::ArgMatches {
             Arg::with_name("input")
                 .help("files or paths")
                 .index(1)
-                .default_value(current_dir)
+                .default_value(current_dir.to_str().unwrap())
                 .required(true)
                 .multiple(true),
         )
@@ -44,7 +45,7 @@ pub fn run() -> Result<Vec<Warning>, Box<dyn Error>> {
         Err(e) => return Err(Box::new(e)),
     };
 
-    let current_dir = current_dir.to_str().unwrap();
+    let current_dir = current_dir.as_os_str();
 
     let args = get_args(current_dir);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,30 +26,12 @@ fn get_args(current_dir: &str) -> clap::ArgMatches {
                 .multiple(true),
         )
         .arg(
-            Arg::with_name("include")
-                .short("i")
-                .long("include")
-                .value_name("FILE_NAME")
-                .help("Includes files to check")
-                .multiple(true)
-                .takes_value(true),
-        )
-        .arg(
             Arg::with_name("exclude")
                 .short("e")
                 .long("exclude")
                 .value_name("FILE_NAME")
                 .help("Excludes files from check")
                 .multiple(true)
-                .takes_value(true),
-        )
-        .arg(
-            Arg::with_name("path")
-                .short("p")
-                .long("path")
-                .value_name("DIRECTORY_PATH")
-                .help("Specify the path of the directory where to run dotenv-linter")
-                .multiple(false)
                 .takes_value(true),
         )
         .get_matches()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,11 +3,11 @@ use crate::common::*;
 use clap::Arg;
 use std::env;
 use std::error::Error;
+use std::ffi::OsStr;
 use std::fs;
 use std::fs::File;
 use std::io::{BufRead, BufReader};
 use std::path::PathBuf;
-use std::ffi::OsStr;
 
 mod checks;
 mod common;

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,9 +6,11 @@ use std::process;
 fn main() {
     match dotenv_linter::run() {
         Ok(warnings) => {
-            if !warnings.is_empty() {
-                warnings.iter().for_each(|w| println!("{}", w));
+            if warnings.is_empty() {
+                process::exit(0);
             }
+
+            warnings.iter().for_each(|w| println!("{}", w));
         }
         Err(error) => {
             eprintln!("dotenv-linter: {}", error);

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -254,3 +254,17 @@ fn checks_one_specific_file_twice() {
     drop(file1);
     current_dir.close().unwrap();
 }
+
+#[test]
+fn exits_with_0_on_no_errors() {
+    let current_dir = tempdir().unwrap();
+    let file_path = current_dir.path().join(".env");
+    let mut file = File::create(&file_path).unwrap();
+    writeln!(file, "FOO=bar").unwrap();
+
+    let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
+    cmd.current_dir(&current_dir).assert().success();
+
+    drop(file);
+    current_dir.close().unwrap();
+}


### PR DESCRIPTION
closes #103 
current_dir.to_str is replaced with as_os_str which yields the OsString.
The argument type of get_args() function is changed from &str to &OsStr