### PR TITLE
Use reference for the LineEntry as part of the run method for checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### 🚀 Added
 
 ### 🔧 Changed
+- Use reference for the LineEntry as part of the run method for checks [#111](https://github.com/mgrachev/dotenv-linter/pull/111)
 - New CLI API: Ability to check multiple directories [#99](https://github.com/mgrachev/dotenv-linter/pull/99)
 
 ## [v1.1.2] - 2020-03-13

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### 🚀 Added
 
 ### 🔧 Changed
-- Use reference for the LineEntry as part of the run method for checks [#111](https://github.com/mgrachev/dotenv-linter/pull/111)
+- Use reference for the LineEntry as part of the run method for checks [#111](https://github.com/mgrachev/dotenv-linter/pull/111) ([@TamasFlorin](https://github.com/TamasFlorin))
 - New CLI API: Ability to check multiple directories [#99](https://github.com/mgrachev/dotenv-linter/pull/99)
 
 ## [v1.1.2] - 2020-03-13

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,10 +54,10 @@ impl Default for ExampleChecker {
 }
 
 impl Check for ExampleChecker {
-    fn run(&mut self, line: LineEntry) -> Option<Warning> {
+    fn run(&mut self, line: &LineEntry) -> Option<Warning> {
         // Write your check logic here...
         if line.raw_string.starts_with("EXAMPLE") {
-            Some(Warning::new(line, self.template.clone()))
+            Some(Warning::new(line.clone(), self.template.clone()))
         } else {
             None
         }
@@ -93,7 +93,7 @@ mod tests {
             raw_string: String::from("EXAMPLE=true"),
         };
         let expected = Some(Warning::new(line.clone(), String::from("Example detected")));
-        assert_eq!(expected, checker.run(line));
+        assert_eq!(expected, checker.run(&line));
     }
 }
 ```

--- a/src/checks.rs
+++ b/src/checks.rs
@@ -36,7 +36,6 @@ pub fn run(lines: Vec<LineEntry>) -> Vec<Warning> {
         }
 
         for ch in &mut checks {
-            // TODO: Use a reference instead of the clone method
             if let Some(warning) = ch.run(&line) {
                 warnings.push(warning);
             }

--- a/src/checks.rs
+++ b/src/checks.rs
@@ -10,7 +10,7 @@ mod unordered_keys;
 
 // This trait is used for checks which needs to know of only a single line
 trait Check {
-    fn run(&mut self, line: LineEntry) -> Option<Warning>;
+    fn run(&mut self, line: &LineEntry) -> Option<Warning>;
 }
 
 // Checklist for checks which needs to know of only a single line
@@ -37,7 +37,7 @@ pub fn run(lines: Vec<LineEntry>) -> Vec<Warning> {
 
         for ch in &mut checks {
             // TODO: Use a reference instead of the clone method
-            if let Some(warning) = ch.run(line.clone()) {
+            if let Some(warning) = ch.run(&line) {
                 warnings.push(warning);
             }
         }

--- a/src/checks/duplicated_keys.rs
+++ b/src/checks/duplicated_keys.rs
@@ -16,11 +16,14 @@ impl Default for DuplicatedKeysChecker {
 }
 
 impl Check for DuplicatedKeysChecker {
-    fn run(&mut self, line: LineEntry) -> Option<Warning> {
+    fn run(&mut self, line: &LineEntry) -> Option<Warning> {
         let key = line.get_key()?;
 
         if self.keys.contains(&key) {
-            return Some(Warning::new(line, self.template.replace("{}", &key)));
+            return Some(Warning::new(
+                line.clone(),
+                self.template.replace("{}", &key),
+            ));
         }
 
         self.keys.push(key);
@@ -38,7 +41,7 @@ mod tests {
 
         for assert in asserts {
             let (input, output) = assert;
-            assert_eq!(checker.run(input), output);
+            assert_eq!(checker.run(&input), output);
         }
     }
 

--- a/src/checks/incorrect_delimiter.rs
+++ b/src/checks/incorrect_delimiter.rs
@@ -14,10 +14,13 @@ impl Default for IncorrectDelimiterChecker {
 }
 
 impl Check for IncorrectDelimiterChecker {
-    fn run(&mut self, line: LineEntry) -> Option<Warning> {
+    fn run(&mut self, line: &LineEntry) -> Option<Warning> {
         let key = line.get_key()?;
         if key.trim().chars().any(|c| !c.is_alphanumeric() && c != '_') {
-            return Some(Warning::new(line, self.template.replace("{}", &key)));
+            return Some(Warning::new(
+                line.clone(),
+                self.template.replace("{}", &key),
+            ));
         }
 
         None
@@ -37,7 +40,7 @@ mod tests {
             file_path: PathBuf::from(".env"),
             raw_string: String::from("FOO_BAR=FOOBAR"),
         };
-        assert_eq!(None, checker.run(line));
+        assert_eq!(None, checker.run(&line));
     }
 
     #[test]
@@ -48,7 +51,7 @@ mod tests {
             file_path: PathBuf::from(".env"),
             raw_string: String::from("F1OO=BAR"),
         };
-        assert_eq!(None, checker.run(line));
+        assert_eq!(None, checker.run(&line));
     }
 
     #[test]
@@ -63,7 +66,7 @@ mod tests {
             line.clone(),
             String::from("The FOO-BAR key has incorrect delimiter"),
         ));
-        assert_eq!(expected, checker.run(line));
+        assert_eq!(expected, checker.run(&line));
     }
 
     #[test]
@@ -78,7 +81,7 @@ mod tests {
             line.clone(),
             String::from("The FOO BAR key has incorrect delimiter"),
         ));
-        assert_eq!(expected, checker.run(line));
+        assert_eq!(expected, checker.run(&line));
     }
 
     #[test]
@@ -89,7 +92,7 @@ mod tests {
             file_path: PathBuf::from(".env"),
             raw_string: String::from("FOO-BAR"),
         };
-        assert_eq!(None, checker.run(line));
+        assert_eq!(None, checker.run(&line));
     }
 
     #[test]
@@ -100,7 +103,7 @@ mod tests {
             file_path: PathBuf::from(".env"),
             raw_string: String::from(" FOO=FOOBAR"),
         };
-        assert_eq!(None, checker.run(line));
+        assert_eq!(None, checker.run(&line));
     }
 
     #[test]
@@ -111,7 +114,7 @@ mod tests {
             file_path: PathBuf::from(".env"),
             raw_string: String::from("FOO_BAR =FOOBAR"),
         };
-        assert_eq!(None, checker.run(line));
+        assert_eq!(None, checker.run(&line));
     }
 
     #[test]
@@ -122,7 +125,7 @@ mod tests {
             file_path: PathBuf::from(".env"),
             raw_string: String::from(""),
         };
-        assert_eq!(None, checker.run(line));
+        assert_eq!(None, checker.run(&line));
     }
 
     #[test]
@@ -133,6 +136,6 @@ mod tests {
             file_path: PathBuf::from(".env"),
             raw_string: String::from("F=BAR"),
         };
-        assert_eq!(None, checker.run(line));
+        assert_eq!(None, checker.run(&line));
     }
 }

--- a/src/checks/key_without_value.rs
+++ b/src/checks/key_without_value.rs
@@ -14,7 +14,7 @@ impl Default for KeyWithoutValueChecker {
 }
 
 impl Check for KeyWithoutValueChecker {
-    fn run(&mut self, line: LineEntry) -> Option<Warning> {
+    fn run(&mut self, line: &LineEntry) -> Option<Warning> {
         if !line.raw_string.contains('=') {
             Some(Warning::new(
                 line.clone(),
@@ -39,7 +39,7 @@ mod tests {
             file_path: PathBuf::from(".env"),
             raw_string: String::from("FOO=BAR"),
         };
-        assert_eq!(None, checker.run(line));
+        assert_eq!(None, checker.run(&line));
     }
 
     #[test]
@@ -50,7 +50,7 @@ mod tests {
             file_path: PathBuf::from(".env"),
             raw_string: String::from("FOO="),
         };
-        assert_eq!(None, checker.run(line));
+        assert_eq!(None, checker.run(&line));
     }
 
     #[test]
@@ -65,6 +65,6 @@ mod tests {
             line.clone(),
             String::from("The FOO key should be with a value or have an equal sign"),
         ));
-        assert_eq!(expected, checker.run(line));
+        assert_eq!(expected, checker.run(&line));
     }
 }

--- a/src/checks/leading_character.rs
+++ b/src/checks/leading_character.rs
@@ -14,14 +14,14 @@ impl Default for LeadingCharacterChecker {
 }
 
 impl Check for LeadingCharacterChecker {
-    fn run(&mut self, line: LineEntry) -> Option<Warning> {
+    fn run(&mut self, line: &LineEntry) -> Option<Warning> {
         if line
             .raw_string
             .starts_with(|c: char| c.is_alphabetic() || c == '_')
         {
             None
         } else {
-            Some(Warning::new(line, self.template.clone()))
+            Some(Warning::new(line.clone(), self.template.clone()))
         }
     }
 }
@@ -41,7 +41,7 @@ mod tests {
             file_path: PathBuf::from(".env"),
             raw_string: String::from("FOO=BAR"),
         };
-        assert_eq!(None, checker.run(line));
+        assert_eq!(None, checker.run(&line));
     }
 
     #[test]
@@ -52,7 +52,7 @@ mod tests {
             file_path: PathBuf::from(".env"),
             raw_string: String::from("_FOO=BAR"),
         };
-        assert_eq!(None, checker.run(line));
+        assert_eq!(None, checker.run(&line));
     }
 
     #[test]
@@ -65,7 +65,7 @@ mod tests {
         };
         assert_eq!(
             Some(Warning::new(line.clone(), MESSAGE.to_string())),
-            checker.run(line)
+            checker.run(&line)
         );
     }
 
@@ -79,7 +79,7 @@ mod tests {
         };
         assert_eq!(
             Some(Warning::new(line.clone(), MESSAGE.to_string())),
-            checker.run(line)
+            checker.run(&line)
         );
     }
 
@@ -93,7 +93,7 @@ mod tests {
         };
         assert_eq!(
             Some(Warning::new(line.clone(), MESSAGE.to_string())),
-            checker.run(line)
+            checker.run(&line)
         );
     }
 
@@ -106,7 +106,7 @@ mod tests {
             raw_string: String::from(" FOO=BAR"),
         };
         let expected = Some(Warning::new(line.clone(), MESSAGE.to_string()));
-        assert_eq!(expected, checker.run(line));
+        assert_eq!(expected, checker.run(&line));
     }
 
     #[test]
@@ -118,7 +118,7 @@ mod tests {
             raw_string: String::from("  FOO=BAR"),
         };
         let expected = Some(Warning::new(line.clone(), MESSAGE.to_string()));
-        assert_eq!(expected, checker.run(line));
+        assert_eq!(expected, checker.run(&line));
     }
 
     #[test]
@@ -130,6 +130,6 @@ mod tests {
             raw_string: String::from("\tFOO=BAR"),
         };
         let expected = Some(Warning::new(line.clone(), MESSAGE.to_string()));
-        assert_eq!(expected, checker.run(line));
+        assert_eq!(expected, checker.run(&line));
     }
 }

--- a/src/checks/lowercase_key.rs
+++ b/src/checks/lowercase_key.rs
@@ -14,12 +14,15 @@ impl Default for LowercaseKeyChecker {
 }
 
 impl Check for LowercaseKeyChecker {
-    fn run(&mut self, line: LineEntry) -> Option<Warning> {
+    fn run(&mut self, line: &LineEntry) -> Option<Warning> {
         let key = line.get_key()?;
         if key.to_uppercase() == key {
             None
         } else {
-            Some(Warning::new(line, self.template.replace("{}", &key)))
+            Some(Warning::new(
+                line.clone(),
+                self.template.replace("{}", &key),
+            ))
         }
     }
 }
@@ -37,7 +40,7 @@ mod tests {
             file_path: PathBuf::from(".env"),
             raw_string: String::from("FOO=BAR"),
         };
-        assert_eq!(None, checker.run(line));
+        assert_eq!(None, checker.run(&line));
     }
 
     #[test]
@@ -52,7 +55,7 @@ mod tests {
             line.clone(),
             String::from("The foo_bar key should be in uppercase"),
         ));
-        assert_eq!(expected, checker.run(line));
+        assert_eq!(expected, checker.run(&line));
     }
 
     #[test]
@@ -67,6 +70,6 @@ mod tests {
             line.clone(),
             String::from("The FOo_BAR key should be in uppercase"),
         ));
-        assert_eq!(expected, checker.run(line));
+        assert_eq!(expected, checker.run(&line));
     }
 }

--- a/src/checks/spaces_around_equal.rs
+++ b/src/checks/spaces_around_equal.rs
@@ -14,12 +14,12 @@ impl Default for SpacesAroundEqualChecker {
 }
 
 impl Check for SpacesAroundEqualChecker {
-    fn run(&mut self, line: LineEntry) -> Option<Warning> {
+    fn run(&mut self, line: &LineEntry) -> Option<Warning> {
         let line_splitted = line.raw_string.split('=').collect::<Vec<&str>>();
 
         if let [key, value] = &line_splitted[..] {
             if key.ends_with(' ') || value.starts_with(' ') {
-                return Some(Warning::new(line, self.template.clone()));
+                return Some(Warning::new(line.clone(), self.template.clone()));
             }
         }
 
@@ -42,7 +42,7 @@ mod tests {
             file_path: PathBuf::from(".env"),
             raw_string: String::from("DEBUG_HTTP=true"),
         };
-        assert_eq!(None, checker.run(line));
+        assert_eq!(None, checker.run(&line));
     }
 
     #[test]
@@ -53,7 +53,7 @@ mod tests {
             file_path: PathBuf::from(".env"),
             raw_string: String::from(" DEBUG_HTTP=true"),
         };
-        assert_eq!(None, checker.run(line));
+        assert_eq!(None, checker.run(&line));
     }
 
     #[test]
@@ -64,7 +64,7 @@ mod tests {
             file_path: PathBuf::from(".env"),
             raw_string: String::from("DEBUG_HTTP=true "),
         };
-        assert_eq!(None, checker.run(line));
+        assert_eq!(None, checker.run(&line));
     }
 
     #[test]
@@ -75,7 +75,7 @@ mod tests {
             file_path: PathBuf::from(".env"),
             raw_string: String::from(""),
         };
-        assert_eq!(None, checker.run(line));
+        assert_eq!(None, checker.run(&line));
     }
 
     #[test]
@@ -86,7 +86,7 @@ mod tests {
             file_path: PathBuf::from(".env"),
             raw_string: String::from("DEBUG_HTTP true"),
         };
-        assert_eq!(None, checker.run(line));
+        assert_eq!(None, checker.run(&line));
     }
 
     #[test]
@@ -98,7 +98,7 @@ mod tests {
             raw_string: String::from("DEBUG-HTTP = true"),
         };
         let expected = Some(Warning::new(line.clone(), MESSAGE.to_string()));
-        assert_eq!(expected, checker.run(line));
+        assert_eq!(expected, checker.run(&line));
     }
 
     #[test]
@@ -110,7 +110,7 @@ mod tests {
             raw_string: String::from("DEBUG-HTTP =true"),
         };
         let expected = Some(Warning::new(line.clone(), MESSAGE.to_string()));
-        assert_eq!(expected, checker.run(line));
+        assert_eq!(expected, checker.run(&line));
     }
 
     #[test]
@@ -122,6 +122,6 @@ mod tests {
             raw_string: String::from("DEBUG-HTTP= true"),
         };
         let expected = Some(Warning::new(line.clone(), MESSAGE.to_string()));
-        assert_eq!(expected, checker.run(line));
+        assert_eq!(expected, checker.run(&line));
     }
 }

--- a/src/checks/unordered_keys.rs
+++ b/src/checks/unordered_keys.rs
@@ -16,7 +16,7 @@ impl Default for UnorderedKeysChecker {
 }
 
 impl Check for UnorderedKeysChecker {
-    fn run(&mut self, line: LineEntry) -> Option<Warning> {
+    fn run(&mut self, line: &LineEntry) -> Option<Warning> {
         let key = line.get_key()?;
         self.keys.push(key.clone());
         let mut sorted_keys = self.keys.clone();
@@ -33,7 +33,7 @@ impl Check for UnorderedKeysChecker {
             let another_key = sorted_keys[index + 1].clone();
 
             let warning = Warning::new(
-                line,
+                line.clone(),
                 self.template
                     .replace("{1}", &key)
                     .replace("{2}", &another_key),
@@ -55,7 +55,7 @@ mod tests {
 
         for assert in asserts {
             let (input, output) = assert;
-            assert_eq!(checker.run(input), output);
+            assert_eq!(checker.run(&input), output);
         }
     }
 


### PR DESCRIPTION
This change addresses a `TODO` comment from `checks.rs` which has to do with the way that lines are currently passed to the checkers.

Currently, the line is always cloned when the run method is executed but this might not be necessary in the cases where we do not generate a warning.
In order to only generate clones of the line entries when we actually need them, I have changed the parameter of the `run` method for the checkers to `&LineEntry`.
