### PR TITLE
Use HashSet for DuplicateKeyChecker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### 🚀 Added
 
 ### 🔧 Changed
+- Use HashSet for DuplicateKeyChecker [#113](https://github.com/mgrachev/dotenv-linter/pull/113) ([@TamasFlorin](https://github.com/TamasFlorin))
 - New CLI API: Ability to check multiple directories [#99](https://github.com/mgrachev/dotenv-linter/pull/99)
 - Add exit with the code 0 when there are no warnings [#105](https://github.com/mgrachev/dotenv-linter/pull/105) ([@simPod](https://github.com/simPod))
 

--- a/src/checks/duplicated_keys.rs
+++ b/src/checks/duplicated_keys.rs
@@ -1,15 +1,16 @@
 use crate::checks::Check;
 use crate::common::*;
+use std::collections::HashSet;
 
 pub(crate) struct DuplicatedKeysChecker {
     template: String,
-    keys: Vec<String>,
+    keys: HashSet<String>,
 }
 
 impl Default for DuplicatedKeysChecker {
     fn default() -> Self {
         Self {
-            keys: Vec::new(),
+            keys: HashSet::new(),
             template: String::from("The {} key is duplicated"),
         }
     }
@@ -23,7 +24,7 @@ impl Check for DuplicatedKeysChecker {
             return Some(Warning::new(line, self.template.replace("{}", &key)));
         }
 
-        self.keys.push(key);
+        self.keys.insert(key);
         None
     }
 }


### PR DESCRIPTION
The current `DuplicateKeyChecker` implementation uses a `Vec<String>` to store previously seen keys. This leads to an `O(n)` time-complexity when we check if a key is already present in the keys collection.
In order to improve the time-complexity of this checker, we can use a `HashSet<String>` which has `O(1)` time-complexity (on average) for the `contains` operation.