### PR TITLE
Fix #103: Remove the unwrap method while working with the current directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Use reference for the LineEntry as part of the run method for checks [#111](https://github.com/mgrachev/dotenv-linter/pull/111) ([@TamasFlorin](https://github.com/TamasFlorin))
 - New CLI API: Ability to check multiple directories [#99](https://github.com/mgrachev/dotenv-linter/pull/99)
 - Add exit with the code 0 when there are no warnings [#105](https://github.com/mgrachev/dotenv-linter/pull/105) ([@simPod](https://github.com/simPod))
+- Remove the unwrap method and use platform native OsString to fetch the information about current directory [#115](https://github.com/mgrachev/dotenv-linter/pull/115) ([@kanapuli](https://github.com/kanapuli))
+
+
 
 ## [v1.1.2] - 2020-03-13
 ### 🔧 Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New CLI API: Ability to check multiple directories [#99](https://github.com/mgrachev/dotenv-linter/pull/99)
 - Add exit with the code 0 when there are no warnings [#105](https://github.com/mgrachev/dotenv-linter/pull/105) ([@simPod](https://github.com/simPod))
 
-
-
 ## [v1.1.2] - 2020-03-13
 ### 🔧 Changed
 - Fix --path CLI parameter not canonizing filepaths from directory path passed as argument and not working as intended as a result [#97](https://github.com/mgrachev/dotenv-linter/pull/97) ([@pineapplethief](https://github.com/pineapplethief))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### 🚀 Added
 
 ### 🔧 Changed
+- Remove the unwrap method and use platform native OsString to fetch the information about current directory [#115](https://github.com/mgrachev/dotenv-linter/pull/115) ([@kanapuli](https://github.com/kanapuli))
 - Use HashSet for DuplicateKeyChecker [#113](https://github.com/mgrachev/dotenv-linter/pull/113) ([@TamasFlorin](https://github.com/TamasFlorin))
 - Use reference for the LineEntry as part of the run method for checks [#111](https://github.com/mgrachev/dotenv-linter/pull/111) ([@TamasFlorin](https://github.com/TamasFlorin))
 - New CLI API: Ability to check multiple directories [#99](https://github.com/mgrachev/dotenv-linter/pull/99)
 - Add exit with the code 0 when there are no warnings [#105](https://github.com/mgrachev/dotenv-linter/pull/105) ([@simPod](https://github.com/simPod))
-- Remove the unwrap method and use platform native OsString to fetch the information about current directory [#115](https://github.com/mgrachev/dotenv-linter/pull/115) ([@kanapuli](https://github.com/kanapuli))
 
 
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ use crate::common::*;
 use clap::Arg;
 use std::env;
 use std::error::Error;
+use std::ffi::OsStr;
 use std::fs;
 use std::fs::File;
 use std::io::{BufRead, BufReader};
@@ -11,7 +12,7 @@ use std::path::PathBuf;
 mod checks;
 mod common;
 
-fn get_args(current_dir: &str) -> clap::ArgMatches {
+fn get_args(current_dir: &OsStr) -> clap::ArgMatches {
     clap::App::new(env!("CARGO_PKG_NAME"))
         .about(env!("CARGO_PKG_DESCRIPTION"))
         .author(env!("CARGO_PKG_AUTHORS"))
@@ -21,7 +22,7 @@ fn get_args(current_dir: &str) -> clap::ArgMatches {
             Arg::with_name("input")
                 .help("files or paths")
                 .index(1)
-                .default_value(current_dir)
+                .default_value_os(current_dir)
                 .required(true)
                 .multiple(true),
         )
@@ -44,7 +45,7 @@ pub fn run() -> Result<Vec<Warning>, Box<dyn Error>> {
         Err(e) => return Err(Box::new(e)),
     };
 
-    let current_dir = current_dir.to_str().unwrap();
+    let current_dir = current_dir.as_os_str();
 
     let args = get_args(current_dir);
 


### PR DESCRIPTION
closes #103 
current_dir.to_str is replaced with as_os_str which yields the OsString.
The argument type of get_args() function is changed from &str to &OsStr.

The clap code to get the argument `input` was using default_value method
which was converting OsString to &str. Instead default_value method is
swapped with default_value_os which accepts &OsString

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

<!-- _Please make sure to review and check all of these items:_ -->

#### ✔ Checklist:
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] This PR has been added to [CHANGELOG.md](https://github.com/mgrachev/dotenv-linter/blob/master/CHANGELOG.md) (at the top of the list);
- [x] Tests for the changes have been added (for bug fixes / features);
- [ ] Docs have been added / updated (for bug fixes / features).

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->
