### PR TITLE
[#129] Minimizing Rust Binary Size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### 🚀 Added
 
 ### 🔧 Changed
+- Minimizing Rust Binary Size [#132](https://github.com/mgrachev/dotenv-linter/pull/132) ([@akirill0v](https://github.com/akirill0v))
 - Remove the unwrap method and use platform native OsString to fetch the information about current directory [#115](https://github.com/mgrachev/dotenv-linter/pull/115) ([@kanapuli](https://github.com/kanapuli))
 - Use HashSet for DuplicateKeyChecker [#113](https://github.com/mgrachev/dotenv-linter/pull/113) ([@TamasFlorin](https://github.com/TamasFlorin))
 - Use reference for the LineEntry as part of the run method for checks [#111](https://github.com/mgrachev/dotenv-linter/pull/111) ([@TamasFlorin](https://github.com/TamasFlorin))

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,9 @@ clap = "2.33.0"
 [dev-dependencies]
 assert_cmd = "0.12.0"
 tempfile = "3.1.0"
+
+[profile.release]
+opt-level = 'z'  # Optimize for size.
+lto = true
+codegen-units = 1
+panic = 'abort'


### PR DESCRIPTION
Change `release` profile defaults with values from [min-sized-rust](https://github.com/johnthagen/min-sized-rust)

Changes of binary size:
default values: 3.3M
optimized releaseprofile: 1.4M

#### ✔ Checklist:

- [x] This PR has been added to [CHANGELOG.md](https://github.com/mgrachev/dotenv-linter/blob/master/CHANGELOG.md) (at the top of the list);
- [x] Tests for the changes have been added (for bug fixes / features);
- [ ] Docs have been added / updated (for bug fixes / features).

Resolve #129 