### PR TITLE
UnorderedKey: Added check name in message and tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### 🚀 Added
 
 ### 🔧 Changed
+- UnorderedKey: Added check name to the message [#140](https://github.com/mgrachev/dotenv-linter/pull/140) ([@pmk21](https://github.com/pmk21))
 - Add test coverage for CLI --exclude arguments [#135](https://github.com/mgrachev/dotenv-linter/pull/135) ([@sonro](https://github.com/sonro))
 - Renamed check SpacesAroundEqual to SpaceCharacter [#134](https://github.com/mgrachev/dotenv-linter/pull/134) ([@SaMuRa1ReM1X](https://github.com/SaMuRa1ReM1X))
 - Rename check DuplicatedKeys to DuplicatedKey [#133](https://github.com/mgrachev/dotenv-linter/pull/133) ([@sonro](https://github.com/sonro))

--- a/src/checks/unordered_keys.rs
+++ b/src/checks/unordered_keys.rs
@@ -10,7 +10,7 @@ impl Default for UnorderedKeysChecker {
     fn default() -> Self {
         Self {
             keys: Vec::new(),
-            template: String::from("The {1} key should go before the {2} key"),
+            template: String::from("UnorderedKey: The {1} key should go before the {2} key"),
         }
     }
 }
@@ -115,7 +115,7 @@ mod tests {
                         file_path: PathBuf::from(".env"),
                         raw_string: String::from("BAR=FOO"),
                     },
-                    String::from("The BAR key should go before the FOO key"),
+                    String::from("UnorderedKey: The BAR key should go before the FOO key"),
                 )),
             ),
         ];
@@ -146,7 +146,7 @@ mod tests {
                         file_path: PathBuf::from(".env"),
                         raw_string: String::from("BAR=FOO"),
                     },
-                    String::from("The BAR key should go before the FOO key"),
+                    String::from("UnorderedKey: The BAR key should go before the FOO key"),
                 )),
             ),
             (
@@ -161,7 +161,7 @@ mod tests {
                         file_path: PathBuf::from(".env"),
                         raw_string: String::from("ABC=BAR"),
                     },
-                    String::from("The ABC key should go before the BAR key"),
+                    String::from("UnorderedKey: The ABC key should go before the BAR key"),
                 )),
             ),
         ];
@@ -192,7 +192,7 @@ mod tests {
                         file_path: PathBuf::from(".env"),
                         raw_string: String::from("BAR=FOO"),
                     },
-                    String::from("The BAR key should go before the FOO key"),
+                    String::from("UnorderedKey: The BAR key should go before the FOO key"),
                 )),
             ),
             (
@@ -207,7 +207,7 @@ mod tests {
                         file_path: PathBuf::from(".env"),
                         raw_string: String::from("DDD=BAR"),
                     },
-                    String::from("The DDD key should go before the FOO key"),
+                    String::from("UnorderedKey: The DDD key should go before the FOO key"),
                 )),
             ),
         ];
@@ -238,7 +238,7 @@ mod tests {
                         file_path: PathBuf::from(".env"),
                         raw_string: String::from("BAR=FOO"),
                     },
-                    String::from("The BAR key should go before the FOO key"),
+                    String::from("UnorderedKey: The BAR key should go before the FOO key"),
                 )),
             ),
             (
@@ -253,7 +253,7 @@ mod tests {
                         file_path: PathBuf::from(".env"),
                         raw_string: String::from("DDD=BAR"),
                     },
-                    String::from("The DDD key should go before the FOO key"),
+                    String::from("UnorderedKey: The DDD key should go before the FOO key"),
                 )),
             ),
             (

--- a/src/checks/unordered_keys.rs
+++ b/src/checks/unordered_keys.rs
@@ -4,13 +4,27 @@ use crate::common::*;
 pub(crate) struct UnorderedKeysChecker {
     template: String,
     keys: Vec<String>,
+    name: String,
+}
+
+impl UnorderedKeysChecker {
+    fn message(&self, key_one: &str, key_two: &str) -> String {
+        return format!(
+            "{}: {}",
+            self.name,
+            self.template
+                .replace("{1}", key_one)
+                .replace("{2}", key_two)
+        );
+    }
 }
 
 impl Default for UnorderedKeysChecker {
     fn default() -> Self {
         Self {
             keys: Vec::new(),
-            template: String::from("UnorderedKey: The {1} key should go before the {2} key"),
+            name: String::from("UnorderedKey"),
+            template: String::from("The {1} key should go before the {2} key"),
         }
     }
 }
@@ -27,12 +41,7 @@ impl Check for UnorderedKeysChecker {
 
             let another_key = sorted_keys.get(index + 1)?;
 
-            let warning = Warning::new(
-                line.clone(),
-                self.template
-                    .replace("{1}", &key)
-                    .replace("{2}", &another_key),
-            );
+            let warning = Warning::new(line.clone(), self.message(&key, &another_key));
             return Some(warning);
         }
 

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -215,7 +215,7 @@ fn checks_one_specific_file_and_one_path() {
         .failure()
         .code(1)
         .stdout(format!(
-            "{}/{}:2 The FOO key is duplicated\n{}:2 The BAR key should go before the FOO key\n",
+            "{}/{}:2 The FOO key is duplicated\n{}:2 UnorderedKey: The BAR key should go before the FOO key\n",
             relative_path.to_str().unwrap(),
             file_path3.file_name().unwrap().to_str().unwrap(),
             file_path2.file_name().unwrap().to_str().unwrap(),


### PR DESCRIPTION
This PR fixes #126 added the check name `UnorderedKey` to the message and fixed the required tests to show this message as well.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

<!-- _Please make sure to review and check all of these items:_ -->

#### ✔ Checklist:
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] This PR has been added to [CHANGELOG.md](https://github.com/mgrachev/dotenv-linter/blob/master/CHANGELOG.md) (at the top of the list);
- [x] Tests for the changes have been added (for bug fixes / features);
- [ ] Docs have been added / updated (for bug fixes / features).

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->
